### PR TITLE
WIP: Reverse proxy webirc to Kubernetes load balancer

### DIFF
--- a/modules/ocf_irc/manifests/webirc.pp
+++ b/modules/ocf_irc/manifests/webirc.pp
@@ -20,7 +20,7 @@ class ocf_irc::webirc {
       $::hostname,
       $::fqdn,
     ],
-    proxy          => 'http://lb.ocf.berkeley.edu:10008',
+    proxy          => 'http://lb-kubernetes.ocf.berkeley.edu:4080',
     ssl            => true,
   }
 }


### PR DESCRIPTION
This PR will work as soon as we add `irc.ocf.berkeley.edu` and `dev-irc.ocf.berkeley.edu` to the host in https://github.com/ocf/thelounge/blob/master/kubernetes/thelounge.yml.erb#L54.